### PR TITLE
create settings screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,14 +1,15 @@
-import { NavigationContainer } from '@react-navigation/native';
-import React from 'react';
-import { useFonts } from 'expo-font';
-import { Provider } from 'react-redux';
-import StackNavigator from './src/screens/StackNavigator';
-import store from './src/store/store';
-import AlertDialog from './src/components/AlertDialog';
+import React from "react";
+import { NavigationContainer } from "@react-navigation/native";
+import { useFonts } from "expo-font";
+import { Provider } from "react-redux";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import StackNavigator from "./src/screens/StackNavigator";
+import store from "./src/store/store";
+import AlertDialog from "./src/components/AlertDialog";
 
 export default function App() {
   const [loaded] = useFonts({
-    SourceSansPro: require('./assets/font/SourceSansPro-Regular.ttf'),
+    SourceSansPro: require("./assets/font/SourceSansPro-Regular.ttf"),
   });
 
   if (!loaded) {
@@ -17,10 +18,12 @@ export default function App() {
 
   return (
     <Provider store={store}>
-      <NavigationContainer>
-        <StackNavigator />
-      </NavigationContainer>
-      <AlertDialog />
+      <SafeAreaProvider>
+        <NavigationContainer>
+          <StackNavigator />
+        </NavigationContainer>
+        <AlertDialog />
+      </SafeAreaProvider>
     </Provider>
   );
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "dependencies": {
     "@react-navigation/native": "^6.0.2",
     "@react-navigation/stack": "^6.0.7",
+    "@rneui/base": "^4.0.0-rc.5",
+    "@rneui/themed": "^4.0.0-rc.5",
     "expo": "~42.0.1",
     "expo-font": "~9.2.1",
     "expo-splash-screen": "~0.11.2",
@@ -19,7 +21,7 @@
     "react-native": "~0.63.4",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-reanimated": "~2.2.0",
-    "react-native-safe-area-context": "3.2.0",
+    "react-native-safe-area-context": "^4.3.1",
     "react-native-screens": "~3.4.0",
     "react-native-unimodules": "~0.14.5",
     "react-native-web": "~0.13.12",

--- a/src/components/CounterButton.js
+++ b/src/components/CounterButton.js
@@ -1,12 +1,12 @@
-import React from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
-import { FontAwesome5 } from '@expo/vector-icons';
+import React from "react";
+import { StyleSheet, TouchableOpacity } from "react-native";
+import { FontAwesome5 } from "@expo/vector-icons";
 
 const styles = StyleSheet.create({
   button: {
     borderRadius: 8,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
   icon: {
     margin: 8,
@@ -14,11 +14,29 @@ const styles = StyleSheet.create({
 });
 
 export default function CounterButton({
-  icon, size, color, style, onPress,
+  icon,
+  size,
+  color,
+  style,
+  onPress,
+  visible
 }) {
   return (
-    <TouchableOpacity style={[styles.button, { backgroundColor: color }, style]} onPress={onPress}>
-      <FontAwesome5 name={icon} size={size} color="black" style={styles.icon} />
+    <TouchableOpacity
+      disabled={!visible}
+      style={[
+        styles.button,
+        visible ? { backgroundColor: color } : {},
+        style,
+      ]}
+      onPress={onPress}
+    >
+      <FontAwesome5
+        name={icon}
+        size={size}
+        color={visible? "black" : "transparent"}
+        style={styles.icon}
+      />
     </TouchableOpacity>
   );
 }

--- a/src/components/HeaderButtonsGroup.js
+++ b/src/components/HeaderButtonsGroup.js
@@ -12,8 +12,8 @@ const styles = StyleSheet.create({
 export default function HeaderButtonGroup({ buttons }) {
   return (
     <View style={styles.container}>
-      {buttons.map(({ icon, onPress }) => (
-        <HeaderButton icon={icon} onPress={onPress} />
+      {buttons.map(({ icon, onPress }, i) => (
+        <HeaderButton key={i} icon={icon} onPress={onPress} />
       ))}
     </View>
   );

--- a/src/components/HomeListItem.js
+++ b/src/components/HomeListItem.js
@@ -1,35 +1,36 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import { connect } from 'react-redux';
-import { getCounters } from '../store/selectors';
-import { setCounter } from '../store/actions';
-import CounterButton from './CounterButton';
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { connect } from "react-redux";
+import { getCounters } from "../store/selectors";
+import { setCounter } from "../store/actions";
+import CounterButton from "./CounterButton";
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: 'rgba(255, 255, 255, 0.15)',
-    width: '100%',
-    flexDirection: 'row',
+    backgroundColor: "rgba(255, 255, 255, 0.15)",
+    width: "100%",
+    flexDirection: "row",
     paddingVertical: 8,
     paddingHorizontal: 16,
     marginBottom: 4,
+    alignItems: "center",
   },
   counterName: {
     flex: 1,
     marginRight: 16,
-    fontFamily: 'SourceSansPro',
+    fontFamily: "SourceSansPro",
     fontSize: 16,
-    color: 'white',
+    color: "white",
   },
   counter: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
   },
   count: {
     width: 50,
     fontSize: 24,
-    textAlign: 'center',
-    color: 'white',
+    textAlign: "center",
+    color: "white",
   },
   buttonMarginLeft: {
     marginLeft: 8,
@@ -39,22 +40,42 @@ const styles = StyleSheet.create({
   },
 });
 
-function HomeListItem({ counter: { title, count }, setCounterDispatch }) {
+function HomeListItem({
+  counter: { title, count, visibility },
+  setCounterDispatch,
+}) {
   const resetCounter = () => setCounterDispatch({ title, count: 0 });
   const decreaseCounter = () => setCounterDispatch({ title, count: count - 1 });
   const increaseCounter = () => setCounterDispatch({ title, count: count + 1 });
   return (
     <View style={styles.container}>
-      <Text style={styles.counterName}>
-        {title}
-      </Text>
+      <Text style={styles.counterName}>{title}</Text>
       <View style={styles.counter}>
-        <CounterButton icon="redo" size={20} color="#FFEB82" style={styles.buttonMarginRight} onPress={resetCounter} />
-        <CounterButton icon="minus" size={20} color="#FFB156" style={styles.buttonMarginRight} onPress={decreaseCounter} />
-        <Text style={styles.count}>
-          {count}
-        </Text>
-        <CounterButton icon="plus" size={20} color="#C4E975" style={styles.buttonMarginLeft} onPress={increaseCounter} />
+        <CounterButton
+          icon="redo"
+          size={20}
+          visible={visibility.reset}
+          color="#FFEB82"
+          style={styles.buttonMarginRight}
+          onPress={resetCounter}
+        />
+        <CounterButton
+          icon="minus"
+          size={20}
+          color="#FFB156"
+          visible={visibility.decrease}
+          style={styles.buttonMarginRight}
+          onPress={decreaseCounter}
+        />
+        <Text style={styles.count}>{count}</Text>
+        <CounterButton
+          icon="plus"
+          visible={visibility.increase}
+          size={20}
+          color="#C4E975"
+          style={styles.buttonMarginLeft}
+          onPress={increaseCounter}
+        />
       </View>
     </View>
   );

--- a/src/components/SettingsListItem.js
+++ b/src/components/SettingsListItem.js
@@ -1,0 +1,186 @@
+import React, { useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { ListItem, Icon, CheckBox } from "@rneui/themed";
+import { connect } from "react-redux";
+import { getCounters } from "../store/selectors";
+import { setVisibility } from "../store/actions";
+
+const SettingsListItem = ({
+  counter: {
+    title,
+    count,
+    visibility: { reset, decrease, increase },
+  },
+  setCounterDispatch,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const titleText = "Toggle button visibility";
+  const checkBoxColor = "white";
+  const setResetVisibility = () => {
+    setCounterDispatch({
+      title,
+      count: count,
+      visibility: {
+        reset: !reset,
+        decrease: decrease,
+        increase: increase,
+      },
+    });
+  };
+  const setDecreaseVisibility = () => {
+    setCounterDispatch({
+      title,
+      count: count,
+      visibility: {
+        reset: reset,
+        decrease: !decrease,
+        increase: increase,
+      },
+    });
+  };
+  const setIncreaseVisibility = () => {
+    setCounterDispatch({
+      title,
+      count: count,
+      visibility: {
+        reset: reset,
+        decrease: decrease,
+        increase: !increase,
+      },
+    });
+  };
+
+  const onPressAccordianHandler = () => {
+    setExpanded((prev) => !prev);
+  };
+
+  return (
+    <View style={{ marginBottom: 4 }}>
+      <ListItem.Accordion
+        noRotation={true}
+        icon={
+          <Icon
+            name={"caret-down"}
+            color={"white"}
+            type="font-awesome-5"
+            size={21}
+          />
+        }
+        containerStyle={styles.accordian}
+        content={
+          <>
+            <ListItem.Content style={{ marginLeft: 0 }}>
+              <ListItem.Title style={styles.listItemTitle}>
+                {title}
+              </ListItem.Title>
+            </ListItem.Content>
+          </>
+        }
+        isExpanded={expanded}
+        onPress={onPressAccordianHandler}
+      >
+        <View style={styles.optionsView}>
+          <Text style={styles.optionsText}>{titleText}</Text>
+          <View style={styles.checkBoxesView}>
+            <CheckBox
+              containerStyle={styles.checkBoxContainer}
+              checkedColor={checkBoxColor}
+              uncheckedColor={checkBoxColor}
+              center
+              titleProps={{
+                style: styles.checkBoxTitleStyle,
+              }}
+              title="Reset"
+              checked={reset}
+              onPress={setResetVisibility}
+            />
+            <CheckBox
+              containerStyle={styles.checkBoxContainer}
+              checkedColor={checkBoxColor}
+              uncheckedColor={checkBoxColor}
+              center
+              titleProps={{
+                style: styles.checkBoxTitleStyle,
+              }}
+              title="Decrease"
+              checked={decrease}
+              onPress={setDecreaseVisibility}
+            />
+            <CheckBox
+              containerStyle={styles.checkBoxContainer}
+              checkedColor={checkBoxColor}
+              uncheckedColor={checkBoxColor}
+              center
+              titleProps={{
+                style: styles.checkBoxTitleStyle,
+              }}
+              title="Increase"
+              checked={increase}
+              onPress={setIncreaseVisibility}
+            />
+          </View>
+        </View>
+      </ListItem.Accordion>
+    </View>
+  );
+};
+
+const mapStateToProps = (state, ownProps) => ({
+  counter: getCounters(state)[ownProps.title],
+});
+
+const mapDispatchToProps = {
+  setCounterDispatch: setVisibility,
+};
+
+const styles = StyleSheet.create({
+  checkBoxTitleStyle: { color: "#F5F5F5", fontFamily: "SourceSansPro" },
+  checkBoxesView: {
+    width: "100%",
+    flexDirection: "row",
+    paddingTop: 5,
+  },
+  optionsView: {
+    alignItems: "flex-start",
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 20,
+    backgroundColor: "rgba(255,255,255,0.1)",
+  },
+  checkBoxContainer: {
+    paddingLeft: 0,
+    marginLeft: 0,
+    marginBottom: 0,
+    paddingBottom: 0,
+    paddingTop: 0,
+    backgroundColor: "#F5F5F500",
+  },
+  container: {
+    backgroundColor: "rgba(255, 255, 255, 0.15)",
+    width: "100%",
+    flexDirection: "row",
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    marginBottom: 4,
+    alignItems: "center",
+  },
+  accordian: {
+    width: "100%",
+    backgroundColor: "rgba(255,255,255,0.15)",
+    paddingHorizontal: 12,
+  },
+  optionsText: {
+    color: "#F5F5F5",
+    fontFamily: "SourceSansPro",
+    textAlign: "left",
+  },
+  listItemTitle: {
+    color: "#F5F5F5",
+    fontWeight: "400",
+    fontFamily: "SourceSansPro",
+    marginLeft: 0,
+    fontSize: 14,
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SettingsListItem);

--- a/src/screens/StackNavigator.js
+++ b/src/screens/StackNavigator.js
@@ -1,29 +1,40 @@
-import React from 'react';
-import { createStackNavigator } from '@react-navigation/stack';
-import HomeScreen, { homeScreenOptions } from './home/HomeScreen';
-import SettingsScreen from './settings/SettingsScreen';
+import React from "react";
+import { createStackNavigator } from "@react-navigation/stack";
+import HomeScreen, { homeScreenOptions } from "./home/HomeScreen";
+import SettingsScreen, {
+  settingsScreenOptions,
+} from "./settings/SettingsScreen";
 
 const Stack = createStackNavigator();
 
 export default function StackNavigator() {
   return (
-    <Stack.Navigator screenOptions={{
-      headerStyle: {
-        backgroundColor: '#2B5B61',
-        elevation: 0,
-        shadowOpacity: 0,
-        borderBottomWidth: 0,
-      },
-      headerTintColor: 'white',
-      headerShadowVisible: true,
-      headerTitleStyle: {
-        fontFamily: 'SourceSansPro',
-        fontSize: 24,
-      },
-    }}
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: {
+          backgroundColor: "#2B5B61",
+          elevation: 0,
+          shadowOpacity: 0,
+          borderBottomWidth: 0,
+        },
+        headerTintColor: "white",
+        headerShadowVisible: true,
+        headerTitleStyle: {
+          fontFamily: "SourceSansPro",
+          fontSize: 24,
+        },
+      }}
     >
-      <Stack.Screen name="Counters" component={HomeScreen} options={homeScreenOptions} />
-      <Stack.Screen name="Settings" component={SettingsScreen} />
+      <Stack.Screen
+        name="Counters"
+        component={HomeScreen}
+        options={homeScreenOptions}
+      />
+      <Stack.Screen
+        name="Settings"
+        component={SettingsScreen}
+        options={settingsScreenOptions}
+      />
     </Stack.Navigator>
   );
 }

--- a/src/screens/settings/SettingsScreen.js
+++ b/src/screens/settings/SettingsScreen.js
@@ -1,28 +1,76 @@
-import React from 'react';
-import {
-  ImageBackground, StyleSheet, Text,
-} from 'react-native';
-import backgrounGradient from '../../../assets/background-gradient.png';
+import React from "react";
+import { ImageBackground, StyleSheet, Text, View } from "react-native";
+import { connect } from "react-redux";
+import { FontAwesome5 } from "@expo/vector-icons";
+import backgrounGradient from "../../../assets/background-gradient.png";
+import SettingsListItem from "../../components/SettingsListItem";
+import { getCounterOrder } from "../../store/selectors";
+import { setCounter } from "../../store/actions";
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    // backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: "flex-start",
   },
-  sample: {
-    color: 'white',
-    fontFamily: 'SourceSansPro',
+  emptyListContainer: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  emptyListText: {
+    color: "rgba(255,255,255,0.5)",
+    fontFamily: "SourceSansPro",
+    marginTop: 24,
+    marginBottom: 24,
   },
 });
 
-export default function HomeScreen() {
+export const settingsScreenOptions = ({ navigation }) => ({
+  title: "Settings",
+  headerTitleAlign: "left",
+  headerLeft: () => (
+    <View style={{ flexDirection: "row", alignItems: "center" }}>
+      <FontAwesome5
+        name="arrow-left"
+        size={21}
+        style={{ paddingLeft: 16 }}
+        color="white"
+        onPress={() => navigation.goBack()}
+      />
+    </View>
+  ),
+});
+
+const SettingsScreen = ({ counterOrder }) => {
   return (
-    <ImageBackground source={backgrounGradient} resizeMode="stretch" style={styles.container}>
-      <Text style={styles.sample}>
-        Open up src/settings/SettingsScreen.js to start working on your app!
-      </Text>
+    <ImageBackground
+      source={backgrounGradient}
+      resizeMode="stretch"
+      style={styles.container}
+    >
+      {counterOrder && counterOrder.length ? (
+        counterOrder.map((title) => (
+          <SettingsListItem title={title} key={title} />
+        ))
+      ) : (
+        <View style={styles.emptyListContainer}>
+          <FontAwesome5
+            name="clipboard"
+            size={60}
+            color="rgba(255,255,255,0.5)"
+          />
+          <Text style={styles.emptyListText}>
+            You don&apos;t have any counters
+          </Text>
+        </View>
+      )}
     </ImageBackground>
   );
-}
+};
+
+const mapStateToProps = (state) => ({
+  counterOrder: getCounterOrder(state),
+  setCounterDispatch: setCounter,
+});
+
+export default connect(mapStateToProps)(SettingsScreen);

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,23 +1,28 @@
 export const addCounter = (payload) => ({
-  type: 'addCounter',
+  type: "addCounter",
   payload,
 });
 
 export const setCounter = (payload) => ({
-  type: 'setCounter',
+  type: "setCounter",
+  payload,
+});
+
+export const setVisibility = (payload) => ({
+  type: "setVisibility",
   payload,
 });
 
 export const removeCounter = (payload) => ({
-  type: 'removeCounter',
+  type: "removeCounter",
   payload,
 });
 
 export const showAlert = (payload) => ({
-  type: 'showAlert',
+  type: "showAlert",
   payload,
 });
 
 export const hideAlert = () => ({
-  type: 'hideAlert',
+  type: "hideAlert",
 });

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -2,30 +2,36 @@ const initialState = {
   counters: {},
   counterOrder: [],
   showAlert: false,
-  alertType: 'Text', // 'Text'|'Warning'|'Input'
+  alertType: "Text", // 'Text'|'Warning'|'Input'
   alertContent: {},
 };
 
 export default function reducer(state = initialState, action) {
   const { type, payload } = action;
   switch (type) {
-    case 'addCounter':
+    case "addCounter":
       return {
         ...state,
         counters: {
-          ...state.counters, [payload]: { title: payload, count: 0 },
+          ...state.counters,
+          [payload]: {
+            title: payload,
+            count: 0,
+            visibility: { reset: true, decrease: true, increase: true },
+          },
         },
         counterOrder: [payload, ...state.counterOrder],
       };
-    case 'removeCounter':
+    case "removeCounter":
       return {
         ...state,
         counters: {
-          ...state.counters, [payload]: undefined,
+          ...state.counters,
+          [payload]: undefined,
         },
         counterOrder: state.counterOrder.filter((item) => item !== payload),
       };
-    case 'setCounter':
+    case "setCounter":
       return {
         ...state,
         counters: {
@@ -36,14 +42,25 @@ export default function reducer(state = initialState, action) {
           },
         },
       };
-    case 'showAlert':
+    case "setVisibility":
+      return {
+        ...state,
+        counters: {
+          ...state.counters,
+          [payload.title]: {
+            ...state.counters[payload.title],
+            visibility: payload.visibility,
+          },
+        },
+      };
+    case "showAlert":
       return {
         ...state,
         showAlert: true,
         alertType: payload.type,
         alertContent: payload.data,
       };
-    case 'hideAlert':
+    case "hideAlert":
       return {
         ...state,
         showAlert: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1615,6 +1615,23 @@
     color "^3.1.3"
     warn-once "^0.1.0"
 
+"@rneui/base@^4.0.0-rc.5":
+  version "4.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@rneui/base/-/base-4.0.0-rc.5.tgz#6f748df34948ab232a0f0c09838982250f996e28"
+  integrity sha512-N38OiuGUSn4RT+INbl/9gJNGwyIFgIcsGRW0XaSwvFRagIMFPNbIQ5bzsO2cehXhIN2k7dtnp2XR7OlVYx00zw==
+  dependencies:
+    "@types/react-native-vector-icons" "^6.4.10"
+    color "^3.2.1"
+    deepmerge "^4.2.2"
+    hoist-non-react-statics "^3.3.2"
+    react-native-ratings "^8.1.0"
+    react-native-size-matters "^0.4.0"
+
+"@rneui/themed@^4.0.0-rc.5":
+  version "4.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@rneui/themed/-/themed-4.0.0-rc.5.tgz#145debeb541b3fe90bc4b8794b12ba7264eb4a4f"
+  integrity sha512-JkbnDDQe9uEbgWKsPtmRV68alRNu/YBwScwZbNN5BSBFLOpqXbK6Os11j6UZuZG6AuX+SL+j2wE95JUYlS0reA==
+
 "@types/hammerjs@^2.0.36":
   version "2.0.40"
   resolved "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.40.tgz"
@@ -1664,6 +1681,21 @@
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
+
+"@types/react-native-vector-icons@^6.4.10":
+  version "6.4.11"
+  resolved "https://registry.yarnpkg.com/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.11.tgz#8783d4248377aec14e06420397037b96ff242684"
+  integrity sha512-jUy9CsTu1Cl3k6WRE7GnqBRHbuSv55PRVfMEel+fF73HKpF8g5JmTzTVMBDX8NfY3PlfIY5VlxiqWZxdjm38Pg==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-native" "*"
+
+"@types/react-native@*":
+  version "0.69.3"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.69.3.tgz#344074ef5a8b95815128cceb4d1dc212d115faf3"
+  integrity sha512-htIxgvwUlYMFKogynsoMeZgxHq9WVEMJGl1UoVdRFctYCR/gSjapN+vKjxX+eo5qh/WSOYdzC/hOEz0cgLkTtQ==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-redux@^7.1.16":
   version "7.1.18"
@@ -2381,7 +2413,7 @@ color-support@^1.1.3:
   resolved "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
-color@^3.1.3:
+color@^3.1.3, color@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
   integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
@@ -2622,6 +2654,11 @@ deepmerge@^3.2.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz"
   integrity sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==
+
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -5017,6 +5054,13 @@ react-native-gesture-handler@~1.10.2:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
+react-native-ratings@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-ratings/-/react-native-ratings-8.1.0.tgz#3fa9ad29128dc3a88e59518ba151e61c59dd0647"
+  integrity sha512-+QOJ4G3NjVkI1D+tk4EGx1dCvVfbD2nQdkrj9cXrcAoEiwmbep4z4bZbCKmWMpQ5h2dqbxABU8/eBnbDmvAc3g==
+  dependencies:
+    lodash "^4.17.15"
+
 react-native-reanimated@~2.2.0:
   version "2.2.2"
   resolved "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.2.2.tgz"
@@ -5032,12 +5076,22 @@ react-native-safe-area-context@3.2.0:
   resolved "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.2.0.tgz"
   integrity sha512-k2Nty4PwSnrg9HwrYeeE+EYqViYJoOFwEy9LxL5RIRfoqxAq/uQXNGwpUg2/u4gnKpBbEPa9eRh15KKMe/VHkA==
 
+react-native-safe-area-context@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.3.1.tgz#5cf97b25b395e0d09bc1f828920cd7da0d792ade"
+  integrity sha512-cEr7fknJCToTrSyDCVNg0GRdRMhyLeQa2NZwVCuzEQcWedOw/59ExomjmzCE4rxrKXs6OJbyfNtFRNyewDaHuA==
+
 react-native-screens@~3.4.0:
   version "3.4.0"
   resolved "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.4.0.tgz"
   integrity sha512-cg+q9MRnVdeOcJyvJtqffoXLur/C2wHA/7IO2+FAipzTlgHbbM1mTuSM7qG+SeiQjoIs4mHOEf7A0ziPKW04sA==
   dependencies:
     warn-once "^0.1.0"
+
+react-native-size-matters@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-size-matters/-/react-native-size-matters-0.4.0.tgz#01bfd0d59454318f4e0b13fe9c1eb0523d70f2e0"
+  integrity sha512-8/C0htHrFWeUm9N8JegmadovUfgTWkGBkDPZ1N3YkXtDWb+98Ya2gThiKcu445r8c7YhcrBfnHz/mYsXIusaOQ==
 
 react-native-unimodules@~0.14.5:
   version "0.14.9"


### PR DESCRIPTION
Title: 

Create settings screen

Description: 

Create a new settings screen based on supplied Figma Design (Page 1 settings screen). Allows a user to configure which three buttons are visible for each counter.

- Add React Native Elements to support Accordion (has nice animation transition)
- Create SettingsScreen
- hide buttons on Home screen when they are disabled as per state of each counter
- Changed CounterButton so alignment stays when button is disabled
- Modified redux store to support visibility state which tracks reset/decrease/increase visibility toggle state for each counter

![simulator_screenshot_B70D8C60
![simulator_screenshot_843D50A2-1415-489D-A
![simulator_screenshot_A99C2809-F9A6-415E-8F8C-D1EFFEE910F9](https://user-images.githubusercontent.com/57600576/181875878-fcc517e3-3045-4046-84f4-20b842d718d7.png)
7FD-15277B3F736D](https://user-images.githubusercontent.com/57600576/181875871-27e7f40b-1303-450d-bc23-b0c3aa463764.png)
-0D7B-4864-B9B0-5A325A242EB0](https://user-images.githubusercontent.com/57600576/181875865-317790b5-ff4e-4c5d-887b-3b46f2222abf.png)






